### PR TITLE
解决大页面缓存不完全的问题

### DIFF
--- a/Plugin.php
+++ b/Plugin.php
@@ -274,7 +274,7 @@ class MostCache_Plugin implements Typecho_Plugin_Interface
 		try {
                         $installDb->query("CREATE TABLE `$cacheTable` (
                         `hash`      varchar(200)  NOT NULL,
-                        `cache`   text      NOT NULL,
+                        `cache`   longtext      NOT NULL,
                         `dateline` int(10) NOT NULL DEFAULT '0',
                         `expire`  int(8) NOT NULL DEFAULT '0',
                         UNIQUE KEY `hash` (`hash`)


### PR DESCRIPTION
采用mysql方式缓存时，'text' 字段类型的长度限制导致大页面会缓存不完整，改用'longtext'字段类型替代。